### PR TITLE
quoting variables

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -1,9 +1,9 @@
-MYSQL_ROOT_PASSWORD=somerootpassword
+MYSQL_ROOT_PASSWORD="somerootpassword"
 MYSQL_DATABASE=phplistdb
 MYSQL_USER=phplist
 MYSQL_PASSWORD=phplist
-PHPLIST_ADMINNAME=Your Name
-PHPLIST_ADMINPASSWORD=SomeRandomPassword
+PHPLIST_ADMINNAME="Your Name"
+PHPLIST_ADMINPASSWORD="SomeRandomPassword"
 PHPLIST_ADMINEMAIL=YourEmail@Yourdomain.com
 PORT=8000
 HOSTNAME=localhost


### PR DESCRIPTION
Put some values into quotes in order to avoid errors while sourcing.
If there is a white space in the value, start-phplist.sh will fail.