### PR TITLE
Ensure apache config is loaded from local file to avoid remote image …

### DIFF
--- a/phplist-3.3.4.yml
+++ b/phplist-3.3.4.yml
@@ -24,6 +24,7 @@ services:
      image: phplist/phplist:3.3.4
      volumes:
        - images:/var/www/phpList3/public_html/images
+       - ./phplist/docker-apache-phplist.conf:/etc/apache2/sites-enabled/docker-apache-phplist.conf:ro
      ports:
        - "${PORT}:80"
      restart: always

--- a/phplist-3.3.5.yml
+++ b/phplist-3.3.5.yml
@@ -24,6 +24,7 @@ services:
      image: phplist/phplist:3.3.5
      volumes:
        - images:/var/www/phpList3/public_html/images
+       - ./phplist/docker-apache-phplist.conf:/etc/apache2/sites-enabled/docker-apache-phplist.conf:ro
      ports:
        - "${PORT}:80"
      restart: always

--- a/phplist-3.3.6.yml
+++ b/phplist-3.3.6.yml
@@ -24,6 +24,7 @@ services:
      image: phplist/phplist:3.3.6
      volumes:
        - images:/var/www/phpList3/public_html/images
+       - ./phplist/docker-apache-phplist.conf:/etc/apache2/sites-enabled/docker-apache-phplist.conf:ro
      ports:
        - "${PORT}:80"
      restart: always

--- a/phplist-test.yml
+++ b/phplist-test.yml
@@ -21,6 +21,7 @@ services:
        - images:/var/www/phpList3/public_html/images
        - /home/michiel/dev/phpListThemes:/var/www/phpList3/public_html/lists/admin/ui/
        - /home/michiel/dev/phpListPlugins:/var/www/phpList3/public_html/lists/admin/plugins/
+       - ./phplist/docker-apache-phplist.conf:/etc/apache2/sites-enabled/docker-apache-phplist.conf:ro
      ports:
        - "8000:80"
      restart: always

--- a/phplist.yml
+++ b/phplist.yml
@@ -25,6 +25,7 @@ services:
      image: phplist/phplist:latest
      volumes:
        - images:/var/www/phpList3/public_html/images
+       - ./phplist/docker-apache-phplist.conf:/etc/apache2/sites-enabled/docker-apache-phplist.conf:ro
      ports:
        - "${PORT}:80"
      restart: always


### PR DESCRIPTION
…discrepancies.

I hope this is appreciated.

As inspired by issue #5 
The problem is most likely in the last version of the phplist/phplist image as it comes with an apache file that sets the phplist config file in the wrong place as opposed to where it is in the image.

```
root@2d2b14dc5f3f:/# cat /etc/apache2/sites-enabled/docker-apache-phplist.conf 
ServerName phplist.docker
<VirtualHost *:80>
        ServerAdmin webmaster@localhost
        DocumentRoot /var/www/phpList3/public_html/
        SetEnv ConfigFile /etc/phpList3/config.php
        DirectoryIndex index.php
        php_value upload_max_filesize 50M
        php_value post_max_size 100M
</VirtualHost>

```
see line **SetEnv ConfigFile /etc/phpList3/config.php** above

See phpinfo in these cases
https://i.imgur.com/l8G4p8al.png

I cannot directly push a new image, also the process of loading the source code, plugins etc is very lengthy and needs a lot of manual steps. 
As a result please find a PR that ensures the vhost configuration is the latest one as per saved in this repository. 
I have applied the changes in all the docker files without a build instruction as in the one (dev) containing a build instruction it should take the right value. Notice I have not tested this part due to extra manual time needed to set codebase, plugins etc.

Extra notes (feel free to skip but some of these mean easier onboarding process for developers and faster local dev environment) :
- the phplist container as it is takes too long to configure languares and do several other operations before it can actually be browserd. Consider a massive refactor or you can use a waiting script such as https://github.com/bizmate/bash-essentials/blob/master/bin/wait_for_docker.bash . The script cannot be directly used in your context because it assumes the use of a single standard docker-compose but you can see at least that it can be used to wait for a message from the container sdtout to let the user know that the container is ready
- phplist container is a monolith, it looks like some scheduled task and web server run all together in the same container. It is preferable to run tasks in their own container and web server and its process separately when possible.
- phplist container size and base, currently it is based on standard OS and built on top from scratch. Consider removing apache and use a standard php-fpm nginx setup that would take seconds to boot up
- manual steps, I would always steer away from manual steps required such as cp .env file and having a code base to manually import. It is a complex conversation with several aspects to mention but for instance see how i structure everything with a make file instead of bash scripts https://github.com/bizmate/getting-started-rabbitmq-php-dockerised/blob/master/Makefile#L2

:)