### PR TITLE
Use export for exporting variables

### DIFF
--- a/phplist/docker-entrypoint.sh
+++ b/phplist/docker-entrypoint.sh
@@ -11,7 +11,7 @@ echo '#!/bin/bash'
 echo -n
 echo 'exec 6>&1'
 echo 'exec > /dev/null 2>&1'
-printenv | sed 's/^\(.*\)$/export \1/g'
+export
 echo -n
 echo 'exec 1>&6 6>&-'
 echo /usr/bin/php /var/www/phpList3/public_html/lists/admin/index.php -c /var/www/phpList3/config.php \$\*


### PR DESCRIPTION
The current method breaks when env variables with multiples lines are used.